### PR TITLE
Change flight path altitudes to be relative to ground

### DIFF
--- a/kml.js
+++ b/kml.js
@@ -184,12 +184,12 @@ function createFlightPathBlob(launchLocation, waiverLocation, waiverRadius, laun
         
         // flight path coordinates
         stringArray.push(`      <LineString>\n`);
-        stringArray.push(`        <altitudeMode>absolute</altitudeMode>\n`);
+        stringArray.push(`        <altitudeMode>relativeToGround</altitudeMode>\n`);
         stringArray.push(`        <tessellate>1</tessellate>\n`);
         stringArray.push(`        <coordinates>\n`);
         for (let pathIndex = 0; pathIndex < launchSimulationList[index].launchPath.length; ++pathIndex) {
             const pathPoint = launchSimulationList[index].launchPath[pathIndex];
-            const altitude = feetToMeters(launchSimulationList[index].elevation + pathPoint.altitude);
+            const altitude = feetToMeters(pathPoint.altitude);
             stringArray.push(`          ${pathPoint.location.longitude},${pathPoint.location.latitude},${altitude.toFixed(2)}\n`);
         }
         stringArray.push(`        </coordinates>\n`);


### PR DESCRIPTION
Switching line points along flight paths to specify their altitude relative to ground rather than absolute position.

I noticed the start and end points of flight paths were consistently placed hovering in mid-air or buried underground at some launch sites.  Ground elevation values from Open-Elevation, WindsAloft, and Google Earth showed no matches when compared.  Switching altitudeMode from absolute to relativeToGround eliminates the need for adding a the ground elevation value to computed altitudes therefore avoid this issue entirely.