### PR TITLE
Hide Version

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
             <a href="help/index.html">Help</a>
             <a href="about/index.html">About</a>
         </div>
-        <h1>GPS DriftCast Beta</h1>
+        <h1>GPS DriftCast</h1>
         <fieldset class="fieldset_location">
             <legend>Location</legend>
             <p>

--- a/main.js
+++ b/main.js
@@ -706,6 +706,9 @@ function updateDriftResultTable(launchList) {
  * those that are loaded lazily.
  */
 window.onload = () => {
+    // Print a version into the log to help keep track between iterations.
+    console.log('GPS DriftCast 1.0');
+
     const launchDateElement = document.getElementById(launchDateId);
     const startTimeElement = document.getElementById(startTimeId);
     const endTimeElement = document.getElementById(endTimeId);
@@ -1209,12 +1212,6 @@ window.onload = () => {
             console.debug(`Skipping writing a flight path KML file since no simulation data was returned.`);
         }
     });
-
-    
-    const headerOneElement = document.querySelector('h1');
-    if (null != headerOneElement) {
-        headerOneElement.textContent = 'GPS DriftCast 0.6a';
-    }
 }
 
 /**


### PR DESCRIPTION
Removed the version number from the website's header.  It is now logged so developers can keep track of iterations without bothering users.