### PR TITLE
Number Inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,25 +34,25 @@
             </p>
             <p>
                 <label for="launch_site_latitude">*Latitude</label>
-                <input type="text" inputmode="numeric" name="launch_site_latitude" id="launch_site_latitude" value="" placeholder="30.614631"/>
+                <input type="text" name="launch_site_latitude" id="launch_site_latitude" value="" placeholder="30.614631"/>
             </p>
             <p>
                 <label for="launch_site_longitude">*Longitude</label>
-                <input type="text" inputmode="numeric" name="launch_site_longitude" id="launch_site_longitude" value="" placeholder="-97.495914"/>
+                <input type="text" name="launch_site_longitude" id="launch_site_longitude" value="" placeholder="-97.495914"/>
             </p>
             <fieldset>
                 <legend>Waiver</legend>
                 <p>
                     <label for="waiver_latitude">Latitude</label>
-                    <input type="text" inputmode="numeric" class="waiver_input" name="waiver_latitude" id="waiver_latitude" value="" placeholder="30.614167"/>
+                    <input type="text" class="waiver_input" name="waiver_latitude" id="waiver_latitude" value="" placeholder="30.614167"/>
                 </p>
                 <p>
                     <label for="waiver_longitude">Longitude</label>
-                    <input type="text" inputmode="numeric" class="waiver_input" name="waiver_longitude" id="waiver_longitude" value="" placeholder="-97.497501"/>
+                    <input type="text" class="waiver_input" name="waiver_longitude" id="waiver_longitude" value="" placeholder="-97.497501"/>
                 </p>
                 <p>
                     <label for="waiver_radius">Radius</label>
-                    <input type="text" inputmode="numeric" class="waiver_input" name="waiver_radius" id="waiver_radius" value="" placeholder="(nautical miles)"/>
+                    <input type="text" inputmode="decimal" class="waiver_input" name="waiver_radius" id="waiver_radius" value="" placeholder="(nautical miles)"/>
                 </p>
                 <input type="hidden" name="waiver_altitude" id="waiver_altitude" value="0"/>
                 <input type="hidden" name="launch_site_elevation" id="launch_site_elevation" value="-1" />
@@ -92,19 +92,19 @@
                     </p>
                     <p>
                         <label for="launch_apogee" class="recovery_label">*Apogee</label>
-                        <input type="number" class="recovery_input" name="launch_apogee" id="launch_apogee" placeholder="(ft AGL)" />
+                        <input type="text" inputmode="decimal" class="recovery_input" name="launch_apogee" id="launch_apogee" placeholder="(ft AGL)" />
                     </p>
                     <p>
                         <label for="decent_rate_main" class="recovery_label">*Main Descent (ft/s)</label>
-                        <input type="number" class="recovery_input" name="decent_rate_main" id="decent_rate_main" value="20" />
+                        <input type="text" inputmode="decimal" class="recovery_input" name="decent_rate_main" id="decent_rate_main" value="20" />
                     </p>
                     <p>
                         <label for="main_event_altitude" class="recovery_label">Main Event (ft AGL)</label>
-                        <input type="number" class="recovery_input" name="main_event_altitude" id="main_event_altitude" placeholder="N/A" disabled/>
+                        <input type="text" inputmode="decimal" class="recovery_input" name="main_event_altitude" id="main_event_altitude" placeholder="N/A" disabled/>
                     </p>
                     <p>
                         <label for="decent_rate_drogue" class="recovery_label">Drogue Decent (ft/s)</label>
-                        <input type="number" class="recovery_input" name="decent_rate_drogue" id="decent_rate_drogue" placeholder="N/A" disabled/>
+                        <input type="text" inputmode="decimal" class="recovery_input" name="decent_rate_drogue" id="decent_rate_drogue" placeholder="N/A" disabled/>
                     </p>
                 </fieldset>
             </p>
@@ -122,23 +122,23 @@
             </p>
             <p>
                 <span class="weathercock_table_label">5</span>
-                <input type="number" class="weathercock_table" name="weathercock_distance_five" id="weathercock_distance_five" value="0" />
-                <input type="number" class="weathercock_table" name="weathercock_apogee_five" id="weathercock_apogee_five" value="0" />
+                <input type="text" inputmode="decimal" class="weathercock_table" name="weathercock_distance_five" id="weathercock_distance_five" value="0" />
+                <input type="text" inputmode="decimal" class="weathercock_table" name="weathercock_apogee_five" id="weathercock_apogee_five" value="0" />
             </p>
             <p>
                 <span class="weathercock_table_label">10</span>
-                <input type="number" class="weathercock_table" name="weathercock_distance_ten" id="weathercock_distance_ten" value="0" />
-                <input type="number" class="weathercock_table" name="weathercock_apogee_ten" id="weathercock_apogee_ten" value="0" />
+                <input type="text" inputmode="decimal" class="weathercock_table" name="weathercock_distance_ten" id="weathercock_distance_ten" value="0" />
+                <input type="text" inputmode="decimal" class="weathercock_table" name="weathercock_apogee_ten" id="weathercock_apogee_ten" value="0" />
             </p>
             <p>
                 <span class="weathercock_table_label">15</span>
-                <input type="number" class="weathercock_table" name="weathercock_distance_fifteen" id="weathercock_distance_fifteen" value="0" />
-                <input type="number" class="weathercock_table" name="weathercock_apogee_fifteen" id="weathercock_apogee_fifteen" value="0" />
+                <input type="text" inputmode="decimal" class="weathercock_table" name="weathercock_distance_fifteen" id="weathercock_distance_fifteen" value="0" />
+                <input type="text" inputmode="decimal" class="weathercock_table" name="weathercock_apogee_fifteen" id="weathercock_apogee_fifteen" value="0" />
             </p>
             <p>
                 <span class="weathercock_table_label">20</span>
-                <input type="number" class="weathercock_table" name="weathercock_distance_twenty" id="weathercock_distance_twenty" value="0" />
-                <input type="number" class="weathercock_table" name="weathercock_apogee_twenty" id="weathercock_apogee_twenty" value="0" />
+                <input type="text" inputmode="decimal" class="weathercock_table" name="weathercock_distance_twenty" id="weathercock_distance_twenty" value="0" />
+                <input type="text" inputmode="decimal" class="weathercock_table" name="weathercock_apogee_twenty" id="weathercock_apogee_twenty" value="0" />
             </p>
             <br>
         </div>


### PR DESCRIPTION
Latitude and longitude input fields now use standard, full virtual keyboards on mobile since IOS does not include a negative sign on their numeric keypads.

All other input fields that expect numbers have been switched to type 'text' with inputmode 'numeric'.  This appears to offer better results across various platforms.