### PR TITLE
Weathercock commas

### DIFF
--- a/main.js
+++ b/main.js
@@ -1268,13 +1268,13 @@ function getWeathercockInputValues(windSpeed, speedId) {
         return null;
     }
             
-    const distanceValue = parseInt(distanceInput.value);
+    const distanceValue = parseInt(distanceInput.value.replaceAll(',', ''));
     if (isNaN(distanceValue)) {
         console.debug(`Weathercock distance is not a valid integer: ${distanceValue}`);
         return null;
     }
 
-    const apogeeValue = parseInt(apogeeInput.value);
+    const apogeeValue = parseInt(apogeeInput.value.replaceAll(',', ''));
     if (isNaN(distanceValue)) {
         console.debug(`Weathercock apogee is not a valid integer: ${apogeeValue}`);
         return null;


### PR DESCRIPTION
Allow users to enter distance values containing commas for weathercocking.  Neglected to include this in the previous commit.